### PR TITLE
Fix CORS support

### DIFF
--- a/crates/figma-agent/src/main.rs
+++ b/crates/figma-agent/src/main.rs
@@ -22,8 +22,8 @@ async fn main() -> io::Result<()> {
             .wrap(Logger::default())
             .wrap(
                 Cors::default()
-                    .allowed_methods(vec!["GET"])
                     .allowed_origin(ORIGIN)
+                    .allowed_methods(vec!["GET"])
                     .allow_private_network_access(),
             )
             .service(

--- a/crates/figma-agent/src/main.rs
+++ b/crates/figma-agent/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> io::Result<()> {
             .wrap(Logger::default())
             .wrap(
                 Cors::default()
+                    .allowed_methods(vec!["GET"])
                     .allowed_origin(ORIGIN)
                     .allow_private_network_access(),
             )


### PR DESCRIPTION
`cors.default()` doesn't allow anything, so the GET method needs to be enabled.

From the docs https://docs.rs/actix-cors/latest/src/actix_cors/builder.rs.html#494-499
```rust
impl Default for Cors {
    /// A restrictive (security paranoid) set of defaults.
    ///
    /// *No* allowed origins, methods, request headers or exposed headers. Credentials
    /// not supported. No max age (will use browser's default).
    fn default() -> Cors {
```
