### PR TITLE
freetype-sys: fix bindgen FT_Err enums

### DIFF
--- a/crates/freetype-sys/build.rs
+++ b/crates/freetype-sys/build.rs
@@ -18,7 +18,8 @@ fn main() {
         .parse_callbacks(Box::new(CargoCallbacks::new()))
         .clang_args(clang_args)
         .ctypes_prefix("::libc")
-        .allowlist_file(r".+[/\\]freetype[/\\].+")
+        .allowlist_file(r".+[/\\]freetype[/\\].+|.+[/\\]freetype\.h")
+        .prepend_enum_name(false)
         .generate()
         .unwrap();
 

--- a/crates/freetype-sys/include/freetype.h
+++ b/crates/freetype-sys/include/freetype.h
@@ -1,8 +1,9 @@
 #include <ft2build.h>
 
 #define FT_INCLUDE_ERR_PROTOS
-#define FT_ERRORDEF(e, v, s) const FT_Error e = v;
-#define FT_MODERRDEF(e, v, s) const FT_Error FT_Mod_Err_##e = v;
+#define FT_ERRORDEF( e, v, s )  e = v,
+#define FT_ERROR_START_LIST     enum FT_ERR : FT_Error {
+#define FT_ERROR_END_LIST       FT_ERR_CAT( FT_ERR_PREFIX, Max ) };
 
 #include FT_FREETYPE_H
 #include FT_MODULE_H


### PR DESCRIPTION
Since (unknown version), freetype-sys fails to build.

I'm on Fedora rawhide. Tested the changes locally and it works well.